### PR TITLE
Potential fix for code scanning alert no. 6: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.3.1",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -3,6 +3,7 @@ import { Strategy as LocalStrategy } from "passport-local";
 import { Express } from "express";
 import session from "express-session";
 import bcrypt from "bcrypt";
+import { csrf } from "lusca";
 import { storage } from "./storage";
 import { User as SelectUser } from "@shared/schema";
 
@@ -38,6 +39,7 @@ export function setupAuth(app: Express) {
   app.use(session(sessionSettings));
   app.use(passport.initialize());
   app.use(passport.session());
+  app.use(csrf());
 
   // Use email instead of username for Brazilian context
   passport.use(


### PR DESCRIPTION
Potential fix for [https://github.com/leonardobora/validai-proex-2025/security/code-scanning/6](https://github.com/leonardobora/validai-proex-2025/security/code-scanning/6)

The correct fix is to add explicit CSRF protection middleware to the Express app after the session and Passport middlewares in the `setupAuth` function. The recommended practice (per the error and Express documentation) is to use a well-known library such as `lusca` (https://www.npmjs.com/package/lusca) to provide CSRF protection. 

Steps:
1. Import the `csrf` middleware from `lusca` at the top of the file.
2. Immediately after setting up `app.use(session(...))`, `app.use(passport.initialize())`, and `app.use(passport.session())`, add `app.use(csrf())`. This ensures the CSRF token has access to the session and can generate/store tokens as needed.
3. No modifications to existing logic are required; lusca's CSRF middleware defaults are secure.
4. If you want to exempt some APIs, you can add exemptions later; the initial fix should be broad.

Changes to make:
- Import `csrf` from `lusca`
- Add `app.use(csrf())` as the next line after the existing session/passport middleware in `setupAuth`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
